### PR TITLE
Augment the RFC3164 parser to handle messages without a tag

### DIFF
--- a/src/rfc3164.rs
+++ b/src/rfc3164.rs
@@ -9,7 +9,7 @@ use crate::{
 use chrono::prelude::*;
 use nom::{
     bytes::complete::{is_not, tag, take_while},
-    character::complete::{space0, space1},
+    character::complete::space0,
     combinator::{map, opt, rest},
     sequence::{delimited, preceded, tuple},
     IResult,
@@ -69,8 +69,8 @@ where
             pri,
             opt(space0),
             timestamp_3164(get_year, tz),
-            opt(preceded(space1, hostname)),
-            opt(preceded(space1, tagname)),
+            opt(preceded(tag(" "), hostname)),
+            opt(preceded(tag(" "), tagname)),
             opt(space0),
             opt(tag(":")),
             opt(space0),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -221,6 +221,31 @@ fn parse_3164_invalid_structured_data() {
 }
 
 #[test]
+fn parse_3164_no_tag() {
+    let msg = "<46>Jan  5 15:33:03 plertrood-ThinkPad-X220  [software=\"rsyslogd\" swVersion=\"8.32.0\" x-pid=\"20506\" x-info=\"http://www.rsyslog.com\"] start";
+
+    assert_eq!(
+        parse_message_with_year(msg, with_year),
+        Message {
+            facility: Some(SyslogFacility::LOG_SYSLOG),
+            severity: Some(SyslogSeverity::SEV_INFO),
+            timestamp: Some(
+                FixedOffset::west(0)
+                    .ymd(2020, 1, 5)
+                    .and_hms_milli(15, 33, 3, 0)
+            ),
+            hostname: Some("plertrood-ThinkPad-X220"),
+            appname: None,
+            procid: None,
+            msgid: None,
+            protocol: Protocol::RFC3164,
+            structured_data: vec![],
+            msg: "start",
+        }
+    );
+}
+
+#[test]
 fn parse_european_chars() {
     let msg = "<46>Jan 5 10:01:00 Übergröße außerplanmäßig größenordnungsmäßig";
 


### PR DESCRIPTION
A Vector user reported poor behavior when sending messages that had
a hostname but not tag: https://github.com/timberio/vector/issues/4811

Their example socket data seemed to indicate that there was an empty tag
due to the existence of two spaces between the hostname and the
message.

RFC3164 is a little vague on whether this would be a valid message:
https://tools.ietf.org/html/rfc3164#section-4.1.3

But RFC5424 does ducoment what a message lacking the app-name field
would look like (https://tools.ietf.org/html/rfc5424#section-6) which
would look like this, with two spaces in a row.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>